### PR TITLE
Automatically enforce narrator filter on Audible searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Audible Virtual Voice Modifier
 
-This userscript removes "Virtual Voice" AI-Generated audiobooks from Audible.com's browsing pages by adding a checkbox to toggle the removal of the "Virtual Voice" keyword from the URL.
+This userscript removes "Virtual Voice" AI-Generated audiobooks from Audible.com's browsing pages by automatically appending the narrator filter `-virtual` to Audible search URLs.
 
 I've tested this on the US site, but it is currently set up to work with the UK and Canadian URLs as well, nothing should change with those, but any extra testing would be greatly appreciated.
 
@@ -16,11 +16,10 @@ To use this script, you'll need a userscript extension such as Tampermonkey or G
 
    [Install Audible Virtual Voice Modifier](https://greasyfork.org/en/scripts/487538-audible-virtual-voice-remover)
 
-3. Once the extension is installed and the script is enabled, visit Audible.com and you should see a checkbox labeled "Remove Virtual Voice". Checking this box will remove the "Virtual Voice" from the results, updating the page content accordingly.
+3. Once the extension is installed and the script is enabled, visit Audible.com and any search results will automatically exclude Virtual Voice audiobooks. To see Virtual Voice titles again, temporarily disable the script in your userscript manager.
 
 ## How it Works
 
-The script adds a checkbox to the Audible.com page that allows you to toggle the removal of the "Virtual Voice" keyword from the URL. When the checkbox is checked, the script appends `&keywords=-virtual_voice` to the URL, effectively removing "Virtual Voice" from the search results.
-Currently, you cannot remove the check (and remove the results). I am working on an update for that now.
+The script monitors Audible's search pages and ensures that the narrator filter `-virtual` is present in the URL. Whenever the filter is missing (for example, when navigating to a new search page), the script updates the URL to add `&narrator=-virtual`, which removes "Virtual Voice" results.
 
 Please note that this script is intended for personal use and may not work as expected on all pages or under all circumstances. Use at your own risk.

--- a/remove-virtual-voice.js
+++ b/remove-virtual-voice.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Audible Virtual Voice Remover
 // @namespace    https://www.briansbookblog.com
-// @version      0.34
+// @version      1.0.0
 // @description  Remove Virtual Voice from Audible.com's browsing pages.
 // @author       Brian @ briansbookblog.com
 // @match        https://www.audible.com/*
@@ -13,57 +13,44 @@
  
 (function() {
     'use strict';
- 
-    const checkboxId = 'enableCheckbox';
- 
-    function modifyURL() {
-    const checkbox = document.getElementById(checkboxId);
- 
-    if (checkbox) {
-        const currentUrl = new URL(window.location.href);
-        const keywordsParam = currentUrl.searchParams.get('keywords');
-        const isChecked = checkbox.checked;
- 
-        if (isChecked) {
-            if (keywordsParam && !keywordsParam.includes("-virtual_voice")) {
-                currentUrl.searchParams.set('keywords', keywordsParam + ' -virtual_voice');
-            } else {
-                currentUrl.searchParams.set('keywords', '-virtual_voice');
-            }
-        } else {
-            if (keywordsParam && keywordsParam.includes("-virtual_voice")) {
-                currentUrl.searchParams.set('keywords', keywordsParam.replace(/-virtual_voice/g, ''));
-            }
+
+    if (window.top !== window.self) {
+        return;
+    }
+
+    const narratorFilterValue = '-virtual';
+
+    function ensureNarratorFilter() {
+        if (!window.location.pathname.includes('/search')) {
+            return;
         }
- 
-        window.location.href = currentUrl.toString();
+
+        const url = new URL(window.location.href);
+        const narratorParams = url.searchParams.getAll('narrator');
+        const hasVirtualFilter = narratorParams.some((param) => {
+            return param.split(',').map((value) => value.trim()).includes(narratorFilterValue);
+        });
+
+        if (!hasVirtualFilter) {
+            url.searchParams.set('narrator', narratorFilterValue);
+            window.location.replace(url.toString());
+        }
     }
-}
- 
-    function addCheckbox() {
-        const checkbox = document.createElement('input');
-        checkbox.type = 'checkbox';
-        checkbox.id = checkboxId;
-        checkbox.style.marginRight = '5px';
- 
-        const label = document.createElement('label');
-        label.appendChild(checkbox);
-        label.appendChild(document.createTextNode(' Remove Virtual Voice'));
-        label.addEventListener('change', modifyURL);
- 
-        const heading = document.createElement('h2');
-        heading.id = 'a-virtualvoice';
-        heading.className = 'bc-text bc-pub-relative bc-accordion-header-text bc-size-base bc-text-bold bc-box bc-box-padding-mini bc-accordion-header-inner bc-accordion-header-content';
-        heading.appendChild(document.createTextNode('Virtual Voice'));
- 
- 
-        const parentElement = document.querySelector('#left-1 > form > section > div.bc-accordion.bc-color-border-base.bc-accordion-borderless.bc-accordion-icon-position-');
-        if (parentElement) {
-            parentElement.insertBefore(label, parentElement.firstChild);
-            parentElement.insertBefore(heading, parentElement.firstChild);
-}
- 
-    }
- 
-    addCheckbox();
+
+    const originalPushState = history.pushState;
+    const originalReplaceState = history.replaceState;
+
+    history.pushState = function(...args) {
+        originalPushState.apply(this, args);
+        ensureNarratorFilter();
+    };
+
+    history.replaceState = function(...args) {
+        originalReplaceState.apply(this, args);
+        ensureNarratorFilter();
+    };
+
+    window.addEventListener('popstate', ensureNarratorFilter);
+
+    ensureNarratorFilter();
 })();


### PR DESCRIPTION
## Summary
- ensure Audible search URLs automatically include the narrator filter `-virtual` to hide virtual voice titles
- handle navigation changes by monitoring history updates and popstate events
- update documentation to describe the new always-on behavior of the userscript

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dff2ec5f5483268283bf46d25e308d